### PR TITLE
style: Add small-screen layout

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "classnames": "^2.2.6",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.14.0",
     "react": "^16.8.6",

--- a/client/src/components/Button/Button.js
+++ b/client/src/components/Button/Button.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import cn from 'classnames';
+
+const Button = ({
+  tag = 'a',
+  bwShade,
+  type, 
+  size, 
+  fullwidth, 
+  outlined, 
+  inverted, 
+  rounded,
+  hovered,
+  focussed,
+  active,
+  loading,
+  disabled,
+  btnStatic,
+  ...props
+}) => {
+
+  let title;
+  if (disabled) {
+    title = 'Disabled button';
+  }
+
+  const defaultProps = {
+    'a': { title },
+    'button': {}
+  }
+  const TagName = (tag === 'button') ? 'button' : 'a';
+  
+  return (
+    <TagName 
+      className={cn(
+        "button",
+        bwShade && `is-${bwShade}`,
+        type && `is-${type}`,
+        size && `is-${size}`,
+        fullwidth && `is-fullwidth`,
+        outlined && `is-outlined`,
+        inverted && `is-inverted`,
+        rounded && `is-rounded`,
+        hovered && `is-hovered`,
+        focussed && `is-focussed`,
+        active && `is-active`,
+        loading && `is-loading`,
+        btnStatic && `is-static`
+      )}
+      { ...defaultProps[TagName] }
+      { ...props }
+    >{props.children}</TagName>
+  )
+}
+
+export default Button;

--- a/client/src/components/Button/tests/Button.test.js
+++ b/client/src/components/Button/tests/Button.test.js
@@ -1,0 +1,85 @@
+import React from "react";
+import { shallow } from "enzyme";
+import Button from "../Button";
+
+describe("<Button />", () => {
+  it("renders 1 sub-component", () => {
+    const btn = shallow(<Button />);
+    expect(btn.children.length).toBe(1);
+  });
+
+  it("should render anchor tag when tag prop is passed as 'a'", () => {
+    const btn = shallow(<Button tag="a" />);
+    expect(btn.type()).toBe('a');
+  })
+
+  it("should not render anchor tag button when tag prop is missing", () => {
+    const btn = shallow(<Button />);
+    expect(btn.type()).toBe('a');
+  })
+
+  it("should render button tag when tag prop is passed as 'button'", () => {
+    const btn = shallow(<Button tag="button" />);
+    expect(btn.type()).toBe('button');
+  })
+
+  it("should render anchor tag when invalid tag prop is passed", () => {
+    const btn = shallow(<Button tag="h1" />);
+    expect(btn.type()).toBe('a');
+  })
+
+  it("should render children correctly", () => {
+    const label = 'My Button Name';
+    const btn = shallow(<Button>{label}</Button>);
+    expect(btn.text()).toBe(label);
+  })
+
+  it("should always have 'button' class", () => {
+    let btn = shallow(<Button />);
+    expect(btn.hasClass('button')).toBe(true);
+
+    btn = shallow(<Button primary />);
+    expect(btn.hasClass('button')).toBe(true);
+
+    btn = shallow(<Button small />);
+    expect(btn.hasClass('button')).toBe(true);
+
+    btn = shallow(<Button rounded />);
+    expect(btn.hasClass('button')).toBe(true);
+
+    btn = shallow(<Button hovered rounded small primary />);
+    expect(btn.hasClass('button')).toBe(true);
+  })
+
+  it("should have class for each type of prop", () => {
+    const button = <Button 
+      type = "danger"
+      bwShade = "dark"
+      size = "large"
+      fullwidth
+      outlined
+      inverted
+      rounded
+      hovered
+      focussed
+      active
+      loading
+    >Label</Button>
+
+    const btn = shallow(button);
+    
+    expect(btn.hasClass('is-danger')).toBe(true);
+    expect(btn.hasClass('is-dark')).toBe(true);
+    expect(btn.hasClass('is-large')).toBe(true);
+    expect(btn.hasClass('is-fullwidth')).toBe(true);
+    expect(btn.hasClass('is-outlined')).toBe(true);
+    expect(btn.hasClass('is-inverted')).toBe(true);
+    expect(btn.hasClass('is-rounded')).toBe(true);
+    expect(btn.hasClass('is-hovered')).toBe(true);
+    expect(btn.hasClass('is-focussed')).toBe(true);
+    expect(btn.hasClass('is-active')).toBe(true);
+    expect(btn.hasClass('is-loading')).toBe(true);
+
+  })
+
+});

--- a/client/src/components/Container/Container.js
+++ b/client/src/components/Container/Container.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const Container = (props) => {
+  return (
+    <section className="section">
+      <div className="container">
+        {props.children}
+      </div>
+    </section>
+  );
+};
+
+export default Container;

--- a/client/src/components/InputField/InputField.js
+++ b/client/src/components/InputField/InputField.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import cn from 'classnames';
+
+const InputField = ({
+  label,
+  labelDirection, 
+  type = "text",
+  className, 
+  placeholder,
+  id,
+  ...props
+}) => {
+  return (
+    <div className={cn(
+      "field",
+      labelDirection && `has-text-${labelDirection}`
+    )}>
+      <label htmlFor={id} className="label">{label}</label>
+      <div className="control">
+        <input 
+          id={id} 
+          type={type} 
+          placeholder={placeholder} 
+          className={cn(
+          "input",
+          className
+        )} />
+      </div>
+    </div>
+  );
+};
+
+export default InputField;

--- a/client/src/components/InputField/tests/InputField.test.js
+++ b/client/src/components/InputField/tests/InputField.test.js
@@ -1,0 +1,28 @@
+import React from "react";
+import { shallow } from "enzyme";
+import InputField from "../InputField";
+
+describe("<InputField />", () => {
+  it("renders 1 sub-component", () => {
+    const signIn = shallow(<InputField />);
+    expect(signIn.children.length).toBe(1);
+  });
+
+  it("input type attribute works properly", () => {
+    const signIn = shallow(<InputField type="password" />);
+    expect(signIn.find('input').prop('type')).toBe('password');
+  })
+
+  it("label works correctly", () => {
+    const label = 'My Label';
+    const signIn = shallow(<InputField label={label} />);
+    expect(signIn.find('label').text()).toEqual(label);
+  })
+
+  it("input className is set correctly", () => {
+    const className = 'my-custom-class';
+    const signIn = shallow(<InputField className={className} />);
+    expect(signIn.find('input').hasClass(className)).toBe(true);
+  })
+
+ });

--- a/client/src/components/SmallContainer/SmallContainer.js
+++ b/client/src/components/SmallContainer/SmallContainer.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import Container from '../Container/Container';
+
+const SmallContainer = (props) => {
+  return (
+    <Container>
+      <div className="columns is-centered">
+        <div className="column is-three-quarters-mobile is-two-thirds-tablet is-half-desktop is-one-third-widescreen is-one-quarter-fullhd">
+          {props.children}  
+        </div>
+      </div>
+    </Container>
+  );
+};
+
+export default SmallContainer;

--- a/client/src/containers/App/App.js
+++ b/client/src/containers/App/App.js
@@ -2,12 +2,15 @@ import React from "react";
 import "./App.css";
 import AppContextProvider from "./AppContext";
 import UserStatus from "../UserStatus";
+import SmallContainer from "../../components/SmallContainer/SmallContainer";
 
 function App() {
   return (
     <div className="App">
       <AppContextProvider>
-        <UserStatus />
+        <SmallContainer>
+          <UserStatus />
+        </SmallContainer>
       </AppContextProvider>
     </div>
   );

--- a/client/src/containers/SignIn/SignIn.css
+++ b/client/src/containers/SignIn/SignIn.css
@@ -1,0 +1,11 @@
+form > figure {
+  margin-bottom: 30px;
+}
+
+figure.image {
+  margin: 0px auto 30px;
+}
+
+.formFooter {
+  margin-top: 40px;
+}

--- a/client/src/containers/SignIn/SignIn.js
+++ b/client/src/containers/SignIn/SignIn.js
@@ -1,0 +1,30 @@
+import React from "react";
+import SmallContainer from '../../components/SmallContainer/SmallContainer';
+import InputField from '../../components/InputField/InputField';
+import './SignIn.css';
+
+function SignIn() {
+  return (
+    <SmallContainer>
+      <form className="has-text-centered">
+        <figure className="image is-128x128">
+          <img src="https://dummyimage.com/100x100/000/fff&text=CoderHood" alt="CoderHood" className="brand-logo is-rounded"/>
+        </figure>
+
+        <InputField labelDirection="left" type="email" id="email" label="Email" />
+        <InputField labelDirection="left" type="password" id="password" label="Password" />
+
+        <div className="control has-text-centered">
+          <button className="button is-primary">Sign In</button>
+        </div>
+
+        <p className="formFooter">
+          Not a registered user?<br />
+          <a href="/signup">Sign Up</a>
+        </p>
+      </form>
+    </SmallContainer>    
+  );
+}
+
+export default SignIn;

--- a/client/src/containers/SignIn/tests/SignIn.test.js
+++ b/client/src/containers/SignIn/tests/SignIn.test.js
@@ -1,0 +1,25 @@
+import React from "react";
+import { mount } from "enzyme";
+import SignIn from "../SignIn";
+
+describe("<SignIn />", () => {
+  it("renders 1 sub-component", () => {
+    const signIn = mount(<SignIn />);
+    expect(signIn.children.length).toBe(1);
+  });
+  
+  it("has email field", () => {
+    const signIn = mount(<SignIn />);
+    expect(signIn.find('input[type="email"]').length).toEqual(1);
+  })
+
+  it("has password field", () => {
+    const signIn = mount(<SignIn />);
+    expect(signIn.find('input[type="password"]').length).toEqual(1);
+  })
+
+  it("has submit button", () => {
+    const signIn = mount(<SignIn />);
+    expect(signIn.find('button').length).toEqual(1);
+  })
+});

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -2,14 +2,16 @@ import React from "react";
 import ReactDOM from "react-dom";
 import "./index.css";
 import App from "./containers/App";
+import SignIn from "./containers/SignIn/SignIn";
 import * as serviceWorker from "./serviceWorker";
-import { Route, BrowserRouter as Router } from "react-router-dom";
+import { Route, BrowserRouter as Router, Switch } from "react-router-dom";
 
 const routing = (
   <Router>
-    <div>
-      <Route path="/" component={App} />
-    </div>
+    <Switch>
+      <Route exact path="/" component={App} />
+      <Route exact path="/signin" component={SignIn} />
+    </Switch>
   </Router>
 );
 


### PR DESCRIPTION
Add frontend layout that can be used in sign in, sign out and forgot
password screens. Add component that can be reused. Add tests that
checks the presence of email, password and submit button.

Refer #19