### PR TITLE
feat(messages): Add Message page for channel discussion

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -9,6 +9,10 @@
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.5/css/bulma.min.css"
     />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.9.0/css/all.min.css"
+    />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <script src="https://kit.fontawesome.com/1d8f3e4878.js"></script>
     <title>Slack Clone</title>

--- a/client/src/components/Columns/Columns.js
+++ b/client/src/components/Columns/Columns.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const Columns = (props) => {
+  return (
+    <section className="columns">
+      {props.children}
+    </section>
+  );
+};
+
+export default Columns;

--- a/client/src/components/Columns/tests/Columns.test.js
+++ b/client/src/components/Columns/tests/Columns.test.js
@@ -1,0 +1,16 @@
+import React from "react";
+import { shallow } from "enzyme";
+import Columns from "../Columns";
+
+describe("<Columns />", () => {
+  it("should render exactly 1 component", () => {
+    const sidebar = shallow(<Columns />);
+    expect(sidebar.children.length).toBe(1);
+  });
+
+  it("should be able to render children", () => {
+    const child = <div className="column">Dummy Column</div>;
+    const sidebar = shallow(<Columns>{child}</Columns>);
+    expect(sidebar.contains(child)).toBe(true);
+  });
+});

--- a/client/src/components/SideTab/SideTab.css
+++ b/client/src/components/SideTab/SideTab.css
@@ -1,0 +1,4 @@
+.isSelected {
+  color: white;
+  background-color: darkslategray;
+}

--- a/client/src/components/SideTab/SideTab.js
+++ b/client/src/components/SideTab/SideTab.js
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import './SideTab.css';
+
+const SideTab = ({ cls, content, id, onClick, ...props }) => {
+  return (
+    <div className={cls}
+      onClick={(e) => onClick(e, id, content)}
+      {...props}
+    >
+      {content}
+    </div>
+  )
+}
+
+export default SideTab

--- a/client/src/components/ThreadForm/ThreadForm.js
+++ b/client/src/components/ThreadForm/ThreadForm.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import Button from '../Button/Button';
+
+const ThreadForm = ({textAreaProps, ...props}) => {
+  return (
+    <article className="media">
+      <div className="media-content">
+        <div className="field">
+          <p className="control">
+            <textarea 
+              rows="1" 
+              className="textarea"
+              placeholder="Add a comment..."
+              {...textAreaProps}
+            ></textarea>
+          </p>
+        </div>
+      </div>
+      <div className="media-right">
+        <Button type="primary" outlined {...props}>Send</Button>
+      </div>
+    </article>
+  )
+}
+
+export default ThreadForm;

--- a/client/src/components/ThreadForm/tests/ThreadForm.test.js
+++ b/client/src/components/ThreadForm/tests/ThreadForm.test.js
@@ -1,0 +1,23 @@
+import React from "react";
+import { shallow, mount } from "enzyme";
+import ThreadForm from "../ThreadForm";
+
+describe("<ThreadForm />", () => {
+
+  it("should render exactly 1 component", () => {
+    const threadForm = shallow(<ThreadForm />);
+    expect(threadForm.children.length).toBe(1);
+  });
+
+  it("should add props to textarea with textAreaProps", () => {
+    const textAreaProps = {rows : 3};
+    const threadForm = shallow(<ThreadForm textAreaProps={textAreaProps} />);
+    expect(threadForm.find('textarea').prop('rows')).toBe(textAreaProps.rows);
+  });
+
+  it("should add props to button", () => {
+    const threadForm = mount(<ThreadForm active />);
+    expect(threadForm.find('.button').hasClass('is-active')).toBe(true);
+  });
+
+});

--- a/client/src/components/ThreadHeader/ThreadHeader.js
+++ b/client/src/components/ThreadHeader/ThreadHeader.js
@@ -1,0 +1,16 @@
+import React from 'react';
+
+const ThreadHeader = ({heading, actions = [], ...props}) => {
+  return (
+    <div className="level has-bottom-border-2">
+      <div className="level-left">
+        <h3>{heading}</h3>
+      </div>
+      <div className="level level-right">
+        {actions.map((action, index) => <span key={index} className="level-item">{action}</span>)}
+      </div>
+    </div>
+  )
+}
+
+export default ThreadHeader;

--- a/client/src/components/ThreadHeader/tests/ThreadHeader.test.js
+++ b/client/src/components/ThreadHeader/tests/ThreadHeader.test.js
@@ -1,0 +1,28 @@
+import React from "react";
+import { shallow, mount } from "enzyme";
+import ThreadHeader from "../ThreadHeader";
+
+describe("<ThreadHeader />", () => {
+
+  it("should render exactly 1 component", () => {
+    const threadHeader = shallow(<ThreadHeader />);
+    expect(threadHeader.children.length).toBe(1);
+  });
+
+  it("should render heading", () => {
+    const heading = "My Custom Heading";
+    const threadHeader = shallow(<ThreadHeader heading={heading} />);
+    expect(threadHeader.find('h3').text()).toBe(heading);
+  });
+
+  it("should render multiple actions", () => {
+    const actions = [
+      <span><a href="/">Some Link</a></span>,
+      <button>Some Button</button>,
+      <i className="some-icon"></i>
+    ];
+    const threadHeader = mount(<ThreadHeader actions={actions} />);
+    expect(threadHeader.find('.level-right .level-item').length).toBe(actions.length);
+  });
+
+});

--- a/client/src/components/ThreadMessage/ThreadMessage.js
+++ b/client/src/components/ThreadMessage/ThreadMessage.js
@@ -1,0 +1,36 @@
+import React from 'react';
+
+const ThreadMessage = ({
+  threadId,
+  userPic, 
+  userName,
+  timeSince,
+  message,
+  messageActions = [],
+  ...props
+}) => {
+  return (
+    <article className="media">
+      <figure className="media-left">
+        <p className="image is-64x64">
+          <img src={userPic} alt={userName} />
+        </p>
+      </figure>
+      <div className="media-content">
+        <div className="content">
+          <p>
+            <strong>{userName}</strong> <small>{timeSince}</small>
+            <br /> {message}
+          </p>
+        </div>
+        <nav className="level is-mobile">
+          <div className="level-left">
+            {messageActions.map(action => <span className="level-item">{action}</span>)}
+          </div>
+        </nav>
+      </div>
+    </article>
+  )
+}
+
+export default ThreadMessage;

--- a/client/src/components/ThreadMessage/tests/ThreadMessage.test.js
+++ b/client/src/components/ThreadMessage/tests/ThreadMessage.test.js
@@ -1,0 +1,12 @@
+import React from "react";
+import { shallow } from "enzyme";
+import ThreadMessage from "../ThreadMessage";
+
+describe("<ThreadMessage />", () => {
+
+  it("should render exactly 1 component", () => {
+    const threadForm = shallow(<ThreadMessage />);
+    expect(threadForm.children.length).toBe(1);
+  });
+
+});

--- a/client/src/components/index.js
+++ b/client/src/components/index.js
@@ -1,2 +1,11 @@
 export { default as NotFound } from './NotFound/NotFound';
 export { default as AuthForm } from './AuthForm/AuthForm';
+export { default as Columns } from './Columns/Columns';
+export { default as SidebarList } from './SidebarList/SidebarList';
+export { default as ThreadHeader } from './ThreadHeader/ThreadHeader';
+export { default as ThreadMessage } from './ThreadMessage/ThreadMessage';
+export { default as ThreadForm } from './ThreadForm/ThreadForm';
+export { default as SideTab } from './SideTab/SideTab';
+export { default as Container } from './Container/Container';
+export { default as Sidebar } from './Sidebar/Sidebar';
+export { default as InputField } from './InputField/InputField';

--- a/client/src/containers/Thread/Thread.css
+++ b/client/src/containers/Thread/Thread.css
@@ -1,0 +1,9 @@
+.thread-body {
+  border-left: 2px solid black;
+}
+.has-bottom-border-2 {
+  border-bottom: 2px solid black;
+}
+.thread-body h3 {
+  font-size: 1.5em;
+}

--- a/client/src/containers/Thread/Thread.js
+++ b/client/src/containers/Thread/Thread.js
@@ -1,0 +1,41 @@
+import React from "react";
+import { 
+  Container, 
+  Sidebar, 
+  Columns, 
+  SidebarList, 
+  ThreadHeader, 
+  ThreadMessage, 
+  ThreadForm
+} from '../../components';
+import './Thread.css';
+
+function Thread() {
+  const members = [];
+  const channels = []; 
+  const headerTitle = "";
+  const headerActions = [];
+  const messages = [];
+
+  return (
+    <Container>
+      <Columns>
+        <Sidebar>
+          <SidebarList list={channels} heading="Channels" action="+" />
+          <SidebarList list={members} heading="Users" action="+" />
+        </Sidebar>
+
+        <div className="column is-9 thread-body">
+          <ThreadHeader heading={headerTitle} actions={headerActions} />
+          
+          {messages.map(message => <ThreadMessage {...message} />)}
+
+          <ThreadForm />
+
+        </div>
+      </Columns>
+    </Container>
+  );
+}
+
+export default Thread;

--- a/client/src/containers/index.js
+++ b/client/src/containers/index.js
@@ -1,3 +1,4 @@
 export { default as SignIn } from './SignIn/SignIn';
 export { default as SignUp } from './SignUp/SignUp';
 export { default as Workspaces } from './Workspaces/Workspaces';
+export { default as Thread } from './Thread/Thread';

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -2,7 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import "./index.css";
 import App from "./containers/App";
-import { SignIn, SignUp, Workspaces } from './containers'
+import { SignIn, SignUp, Thread, Workspaces } from './containers'
 import * as serviceWorker from "./serviceWorker";
 import { Route, BrowserRouter as Router, Switch } from "react-router-dom";
 import { NotFound } from "./components";
@@ -14,6 +14,7 @@ const routing = (
       <Route exact path="/signin" component={SignIn} />
       <Route exact path="/signup" component={SignUp} />
       <Route exact path="/workspaces" component={Workspaces} />
+      <Route exact path="/thread" component={Thread} />
       <Route component={NotFound} />
     </Switch>
   </Router>


### PR DESCRIPTION
Add page layout for channel discussion. Create `ThreadHeader`
component that shows Channel name and takes some actions which
display on the right side. Add Thread Message component which
shows the actual body of single message and includes user name,
time since the message was posted, message and actions to take
on the messages.

On Thread page added dummy data so that can be replaced with
actual information

Refer #19

feat(messages): Add Workspace Listing page

Add workspace listing page where separate list of owned workspaces
and invited workspaces are shown. Add a new plus icon button
that will be used for adding new workspace. There should be
welcome message for the logged in user.

Complete #33
Also see #19

feat(messages): Add SideTab components

Add SideTab component needed for message UI

Refer #19