### PR TITLE
feat: add setting up of namespaces of workspaces for sockets

### DIFF
--- a/server/src/Sockets/setup.js
+++ b/server/src/Sockets/setup.js
@@ -1,0 +1,12 @@
+import { createWorkspaceNamespace, configureEventHandlersForWorkspace } from './socket';
+import { workspaceModel } from '../Model';
+
+const populateWorkspaceAsNamespacesInIO = async () => {
+  const workspaceIds = await workspaceModel.find({}).select('_id');
+  workspaceIds.forEach(({ _id }) => {
+    const nsps = createWorkspaceNamespace(_id);
+    configureEventHandlersForWorkspace(nsps);
+  });
+};
+
+export default populateWorkspaceAsNamespacesInIO;

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -9,6 +9,7 @@ import router from './router';
 import { errorHandler, notFoundRoutes } from './libs/routes';
 import { PORT, MONGO_CONNECTION_STRING } from './configs/config';
 import successHandler from './libs/routes/successHandler';
+import populateWorkspaceAsNamespacesInIO from './Sockets/setup';
 
 const app = express();
 
@@ -36,6 +37,7 @@ export const server = app.listen(PORT, (err) => {
       useNewUrlParser: true,
       useFindAndModify: false,
     });
+    populateWorkspaceAsNamespacesInIO();
   } catch (e) {
     console.error(e);
     server.close(() => console.log('Server stopped.'));


### PR DESCRIPTION
#### what does it do?
Adds a function `populateWorkspacesAsNamespacesOnIO()", which is called when the backend servers start. The function then populates the namespaces on the IO server with the ids of workspaces from DB, so that client sockets can connect to workspaces and start communication.

Solves: #43 