### PR TITLE
Fix(socket-bug): fix bug in typing indicator and socket one to one

### DIFF
--- a/client/src/containers/Workspace/Workspace.js
+++ b/client/src/containers/Workspace/Workspace.js
@@ -126,6 +126,10 @@ function Workspace({ match }) {
 
     const isUserParticipant =
       currentUser._id === to || currentUser._id === from;
+    
+    if (isConversation && !isUserParticipant) {
+      return null;
+    }
 
     if (!channelsLoaded.current.includes(channel)) {
       if (isConversation && isUserParticipant) {
@@ -231,7 +235,10 @@ function Workspace({ match }) {
     const isUserParticipant =
       currentUser._id === to || currentUser._id === from;
 
-    if (isConversation && isUserParticipant) {
+    if (isConversation) {
+      if (!isUserParticipant) {
+        return null;
+      }
       let channelId = channel === currentUser._id ? from : channel;
       if (channelId === activeChannel.id) {
         setTypingNotification({


### PR DESCRIPTION
#### what does this do?
Fix a bug in sockets client-side, which allowed typing indicator and one to one events to be loaded into unrelated user's message stores.